### PR TITLE
Add AdjustWindowRect call, this fixes a bug where the client area window size ends up being incorrect

### DIFF
--- a/main_windows.go
+++ b/main_windows.go
@@ -291,12 +291,20 @@ func openWindow(
 		return 0, errors.New("RegisterClassEx failed")
 	}
 
+	windowStyle := uint(w32.WS_OVERLAPPEDWINDOW | w32.WS_VISIBLE)
+	windowRect := w32.RECT{
+		Left:   0,
+		Top:    0,
+		Right:  int32(width),
+		Bottom: int32(height),
+	}
+	w32.AdjustWindowRect(&windowRect, windowStyle, false)
 	window := w32.CreateWindowEx(
 		0,
 		syscall.StringToUTF16Ptr(className),
 		nil,
-		w32.WS_OVERLAPPEDWINDOW|w32.WS_VISIBLE,
-		x, y, width, height,
+		windowStyle,
+		x, y, int(windowRect.Width()), int(windowRect.Height()),
 		0, 0, 0, nil,
 	)
 	if window == 0 {


### PR DESCRIPTION
Add AdjustWindowRect call, this fixes a bug where the client area window size ends up being incorrect.

I decided to fix the bug here too as this is the project I used as an example for rendering D3D9 things. So if somebody else does the same thing, they'll at least not hit the same bug that I did.

Related to:
https://github.com/gonutz/d3d9/issues/11